### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ layout: layout
 
 # wadl2swagger
 
-[![Latest Version](https://pypip.in/version/wadl2swagger/badge.svg)](https://pypi.python.org/pypi/wadl2swagger/)
+[![Latest Version](https://img.shields.io/pypi/v/wadl2swagger.svg)](https://pypi.python.org/pypi/wadl2swagger/)
 
 wadl2swagger is a command line tool for converting [WADL](http://www.w3.org/Submission/wadl/) description of an API into [Swagger](http://swagger.io). It's intended to work with generic WADL documents as much as possible, but some of the conversion is mapped to conventions used in OpenStack WADL rather concepts defined in the WADL standard itself.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20wadl2swagger))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `wadl2swagger`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.